### PR TITLE
removed changeHandler and added register function that set multiple attributes

### DIFF
--- a/dist/formBuilder.d.ts
+++ b/dist/formBuilder.d.ts
@@ -16,7 +16,14 @@ export declare class FormBuilder {
         value: unknown;
         validators: ((val: string) => Record<string, boolean>)[];
     };
-    changeHandler(key: string): (e: Event) => void;
+    register(key: string): {
+        attrs: {
+            name: string;
+            value: unknown;
+            onchange: (e: Event) => void;
+            onblur: () => void;
+        };
+    };
     reset(): void;
     private _checkValidity;
 }

--- a/dist/formBuilder.js
+++ b/dist/formBuilder.js
@@ -168,12 +168,20 @@ var FormBuilder = /** @class */ (function () {
     FormBuilder.prototype.getControl = function (controlName) {
         return this._controls.get(controlName);
     };
-    FormBuilder.prototype.changeHandler = function (key) {
+    FormBuilder.prototype.register = function (key) {
         var _this = this;
-        return function (e) {
-            var value = _getTargetValue(e.target);
-            _this.getControl(key).value = value;
-            _this._errorCount.set(0);
+        return {
+            attrs: {
+                name: key,
+                value: this.getControl(key).value,
+                onchange: function (e) {
+                    var value = _getTargetValue(e.target);
+                    _this.getControl(key).value = value;
+                },
+                onblur: function () {
+                    _this._checkValidity();
+                },
+            },
         };
     };
     FormBuilder.prototype.reset = function () {

--- a/src/formBuilder.ts
+++ b/src/formBuilder.ts
@@ -116,11 +116,19 @@ export class FormBuilder {
     return this._controls.get(controlName);
   }
 
-  changeHandler(key: string) {
-    return (e: Event) => {
-      const value = _getTargetValue(e.target as HTMLElement);
-      this.getControl(key).value = value;
-      this._errorCount.set(0);
+  register(key: string) {
+    return {
+      attrs: {
+        name: key,
+        value: this.getControl(key).value,
+        onchange: (e: Event) => {
+          const value = _getTargetValue(e.target as HTMLElement);
+          this.getControl(key).value = value;
+        },
+        onblur: () => {
+          this._checkValidity();
+        },
+      },
     };
   }
 


### PR DESCRIPTION
This change made using FormBuilder more user friendly. Devs no longer have to mention change and blur events instead they just interpolate register method on control.